### PR TITLE
Handle 401 errors based on authentication method

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -25,8 +25,16 @@ function handleRequestWithRetry(requestFn, options, callbackData, callbacks) {
         return requestFn(options, callbackData, callbacks);
     } catch (error) {
         sys.logs.info("[googlemeet] Handling request "+JSON.stringify(error));
-        dependencies.oauth.functions.refreshToken('googlemeet:refreshToken');
-        return requestFn(setAuthorization(options), callbackData, callbacks);
+        if (error.additionalInfo.status === 401) {
+            if (config.get("authenticationMethod") === 'oauth') {
+                dependencies.oauth.functions.refreshToken('googledrive:refreshToken');
+            } else { 
+                getAccessTokenForAccount(); // this will attempt to get a new access_token in case it has expired
+            }    
+            return requestFn(setAuthorization(options), callbackData, callbacks);
+        } else {
+            throw error; 
+        } 
     }
 }
 


### PR DESCRIPTION
When I tried a GET request as showed in the package documentation, I got an error saying `Fail to refresh access_token, there is no refresh token`. I compared the api library of the Google Meet package with the Google Drive package and found a difference in how the retry request is handled, so I copied the method of the Drive package. Hope this helps!